### PR TITLE
WB-79 QOL Improvements and Bugfixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,9 @@
         "typescript": "^5.6.2",
         "vite": "^5.4.6",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "vite-plugin-mkcert": "^1.17.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1193,6 +1196,173 @@
       "license": "MIT",
       "dependencies": {
         "svgmoji": "^3.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+      "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.3.0",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.1.tgz",
+      "integrity": "sha512-ryqobs26cLtM1kQxqeZui4v8FeznirUsksiA+RYemMPJ7Micju0WSkv50dBksTuZks9O5cg4wp+t8fZ/cLY56g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.5.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+      "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.2.tgz",
+      "integrity": "sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.5.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.1.tgz",
+      "integrity": "sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.3.1",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.2.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.1.tgz",
+      "integrity": "sha512-PHZE9Z+kWXb23Ndik8MKPirBPziOc0D2/3KH1P+6jK5nGWe96kadZuE4jev2/Jq7FvIfTlT2Ltg8Fv2x1v0a5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^22.2.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4633,6 +4803,13 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -5281,6 +5458,13 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -8147,6 +8331,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/orderedmap": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
@@ -10254,6 +10448,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
@@ -10455,6 +10656,25 @@
         }
       }
     },
+    "node_modules/vite-plugin-mkcert": {
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-1.17.6.tgz",
+      "integrity": "sha512-4JR1RN0HEg/w17eRQJ/Ve2pSa6KCVQcQO6yKtIaKQCFDyd63zGfXHWpygBkvvRSpqa0GcqNKf0fjUJ0HiJQXVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/rest": "^20.1.1",
+        "axios": "^1.7.4",
+        "debug": "^4.3.6",
+        "picocolors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=v16.7.0"
+      },
+      "peerDependencies": {
+        "vite": ">=3"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -10646,6 +10866,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "vite-plugin-mkcert": "^1.17.6"
   }
 }

--- a/src/components/CampaignWrapper/CampaignFavourites.tsx
+++ b/src/components/CampaignWrapper/CampaignFavourites.tsx
@@ -67,7 +67,6 @@ const CampaignFavourites: FunctionComponent = () => {
       <div className="flex-1 items-end space-y-4 mb-4 text-right">
         {!!user?.characters?.length && (
           <div className={'flex-1 space-y-2'}>
-            <SmallSansSerifText size={'xxs'}>Characters</SmallSansSerifText>
             {user.characters.map(({ slug, name }, index) => {
               return (
                 <FavouriteLink

--- a/src/components/CampaignWrapper/CampaignMenu.tsx
+++ b/src/components/CampaignWrapper/CampaignMenu.tsx
@@ -2,7 +2,8 @@ import React, { FunctionComponent, useMemo } from 'react'
 import Menu from '../Nav/Menu'
 import { TCampaign } from '@/types'
 import CampaignMenuItem from './CampaignMenuItem'
-import useAuthUserDataManager from '../../hooks/DataManagers/useAuthUserDataManager'
+import useAuthUserDataManager
+  from '../../hooks/DataManagers/useAuthUserDataManager'
 import { MenuItemInterface } from '../Nav/MenuItemInterface'
 import SearchCampaign from '@/components/CampaignWrapper/SearchCampaign'
 
@@ -13,46 +14,64 @@ const CampaignMenu: FunctionComponent<TProps> = ({ campaign }) => {
 
   const { user } = useAuthUserDataManager()
 
+  const isGamemaster = useMemo(() => {
+    return user?.id === campaign.gameMaster?.id
+  }, [user?.id, campaign.gameMaster?.id])
+
   const menuItems = useMemo(() => {
     const items: MenuItemInterface[] = [
       {
         title: 'The Campaign',
-        to: `/campaigns/${campaign.slug}`
-      }
-    ]
-    if (user?.id === campaign.gameMaster?.id) {
-      items.push(
-        {
-          title: 'Compendium',
-          to: `/campaigns/${campaign.slug}/compendia/${campaign.compendium?.slug}`,
-          hide: !campaign.compendium
-        },
-        {
-          title: 'Scenes',
-          to: `/campaigns/${campaign.slug}/scenes`
-        },
-        {
-          title: 'Quests',
-          to: `/campaigns/${campaign.slug}/quests`
-        },
-        {
-          title: 'Encounters',
-          to: `/campaigns/${campaign.slug}/encounters`
-        }
-      )
-    }
-    items.push(
-      {
-        title: 'Sessions',
-        to: `/campaigns/${campaign.slug}/sessions`
+        to: `/campaigns/${campaign.slug}`,
       },
-      {
-        title: 'Notes',
-        to: `/campaigns/${campaign.slug}/notes`
-      }
-    )
-    return items;
-  }, [campaign.slug, campaign.compendium, user?.id, campaign.gameMaster?.id])
+    ]
+    if (campaign.compendium) {
+      items.push({
+        title: 'Compendium',
+        to: `/campaigns/${campaign.slug}/compendia/${campaign.compendium?.slug}`,
+        hide: !campaign.compendium,
+      })
+    }
+    if (isGamemaster || campaign.scenes.length > 0) {
+      items.push({
+        title: 'Scenes',
+        to: `/campaigns/${campaign.slug}/scenes`,
+      })
+    }
+
+    if (isGamemaster || campaign.quests.length > 0) {
+      items.push({
+        title: 'Quests',
+        to: `/campaigns/${campaign.slug}/quests`,
+      })
+    }
+
+    if (isGamemaster || campaign.encounters.length > 0) {
+      items.push({
+        title: 'Encounters',
+        to: `/campaigns/${campaign.slug}/encounters`,
+      })
+    }
+    if (isGamemaster || campaign.sessions.length > 0) {
+      items.push({
+        title: 'Sessions',
+        to: `/campaigns/${campaign.slug}/sessions`,
+      })
+    }
+    items.push({
+      title: 'Notes',
+      to: `/campaigns/${campaign.slug}/notes`,
+    })
+    return items
+  }, [
+    campaign.slug,
+    campaign.compendium,
+    isGamemaster,
+    campaign.scenes.length,
+    campaign.quests.length,
+    campaign.encounters.length,
+    campaign.sessions.length
+  ])
 
   return (
     <div className="fixed top-20 w-full z-50">

--- a/src/components/CampaignWrapper/FavouriteLink.tsx
+++ b/src/components/CampaignWrapper/FavouriteLink.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom'
+import { FloatingBox } from '@/components/FloatingBox'
+import SansSerifText from '@/components/SmallSansSerifText'
+import React, { FunctionComponent } from 'react'
+import { TFloatingBoxProps } from '@/components/FloatingBox/FloatingBox'
+
+export type CampaignFavouriteLink = {
+  link: string,
+  name: string,
+};
+const FavouriteLink: FunctionComponent<CampaignFavouriteLink & TFloatingBoxProps> = ({link, name, ...props}) => {
+  return (
+    <div>
+      <Link to={link}>
+        <FloatingBox
+          size={'sm'}
+          className={`transition-all duration-1000 hover:bg-yellow-600`}
+          {...props}
+        >
+          <SansSerifText className={'mx-2'}>{name}</SansSerifText>
+        </FloatingBox>
+      </Link>
+    </div>
+  )
+}
+
+export default FavouriteLink

--- a/src/components/FloatingBox/FloatingBox.tsx
+++ b/src/components/FloatingBox/FloatingBox.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {cva, VariantProps} from "class-variance-authority";
-import {cn} from "../../lib/utils";
+import {cn} from '@/lib/utils';
 
 const boxVariants = cva(
     'antialiased rounded-3xl shadow-md border shadow-stone-950',
@@ -30,8 +30,8 @@ const boxVariants = cva(
     }
 )
 
-export type TProps = React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof boxVariants>
-const FloatingBox = React.forwardRef<HTMLDivElement, TProps>(
+export type TFloatingBoxProps = React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof boxVariants>
+const FloatingBox = React.forwardRef<HTMLDivElement, TFloatingBoxProps>(
     ({ className, color, size, border, ...props }, ref) => {
       return (
           <div

--- a/src/components/Forms/Fields/FieldMapper.tsx
+++ b/src/components/Forms/Fields/FieldMapper.tsx
@@ -78,8 +78,7 @@ const FieldMapper: FunctionComponent<TProps> = ({
               disabled={disabled}
             />
           )}
-          {props.type === 'multiSelect' &&
-            (((props.options?.length ?? 0) > 0) || props.dialogType) && (
+          {props.type === 'multiSelect' && (((props.options?.length ?? 0) > 0) || (props.dialogType)) && (
               <MultipleSelectField
                 label={label}
                 required={required}

--- a/src/components/Forms/Fields/MultipleSelectField.tsx
+++ b/src/components/Forms/Fields/MultipleSelectField.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom'
 import { TSelectOption } from './FieldMapper'
 import Label from './Label'
 import Dialog from '../../Dialogs'
-import { TDialogTypes } from '../../../hooks/fieldTools/types'
+import { TDialogTypes } from '@/hooks/fieldTools/types'
 
 type TProp = {
   label: string;
@@ -59,52 +59,56 @@ const MultipleSelectField: FunctionComponent<TProp> = ({
             ) : (
               <div className="text-stone-500 italic">Nothing here</div>
             )}
-            <div className="w-full flex justify-between py-2 rounded-lg focus:bg-stone-800">
-              <Combobox.Button className="w-full flex justify-between">
-                <Combobox.Input
-                  className="w-full bg-transparent outline-none"
-                  onChange={(event) => setQuery(event.target.value)}
-                  displayValue={(option: TSelectOption) => option?.name}/>
-                {!disabled && (
-                  <ChevronDownIcon className="text-stone-300 h-5 w-5"/>
-                )}
-              </Combobox.Button>
-              {dialogType && (
-                <PlusIcon
-                  className="text-stone-300 h-5 w-5 cursor-pointer"
-                  onClick={() => setDialogIsOpen('new')}
-                />
-              )}
-            </div>
-            <Transition
-              show={open}
-              as={Fragment}
-              leave="transition ease-in duration-100"
-              leaveFrom="opacity-100"
-              leaveTo="opacity-0"
-            >
-              <Combobox.Options
-                className="absolute z-20 left-0 top-full mt-1 max-h-56 w-full overflow-auto rounded-md bg-stone-800 px-3 py-2 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-                {!filteredOptions.length && (
-                  <li className="py-1 text-stone-600">No results found.</li>
-                )}
-                {filteredOptions.map((option) => (
-                  <Combobox.Option
-                    key={option.id}
-                    value={option}
-                    as={Fragment}
-                  >
-                    {({ active, selected }) => (
-                      <li className={`py-1 flex justify-between cursor-pointer`}>
-                        {option.name}
-                        {selected && <CheckIcon className="text-stone-300 h-5 w-5"/>}
-                        {!selected && active && <DotIcon className="text-stone-300 h-5 w-5"/>}
-                      </li>
+            {!disabled && (
+              <>
+                <div className="w-full flex justify-between py-2 rounded-lg focus:bg-stone-800">
+                  <Combobox.Button className="w-full flex justify-between">
+                    <Combobox.Input
+                      className="w-full bg-transparent outline-none"
+                      onChange={(event) => setQuery(event.target.value)}
+                      displayValue={(option: TSelectOption) => option?.name}/>
+                    {!disabled && (
+                      <ChevronDownIcon className="text-stone-300 h-5 w-5"/>
                     )}
-                  </Combobox.Option>
-                ))}
-              </Combobox.Options>
-            </Transition>
+                  </Combobox.Button>
+                  {dialogType && (
+                    <PlusIcon
+                      className="text-stone-300 h-5 w-5 cursor-pointer"
+                      onClick={() => setDialogIsOpen('new')}
+                    />
+                  )}
+                </div>
+                <Transition
+                  show={open}
+                  as={Fragment}
+                  leave="transition ease-in duration-100"
+                  leaveFrom="opacity-100"
+                  leaveTo="opacity-0"
+                >
+                  <Combobox.Options
+                    className="absolute z-20 left-0 top-full mt-1 max-h-56 w-full overflow-auto rounded-md bg-stone-800 px-3 py-2 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+                    {!filteredOptions.length && (
+                      <li className="py-1 text-stone-600">No results found.</li>
+                    )}
+                    {filteredOptions.map((option) => (
+                      <Combobox.Option
+                        key={option.id}
+                        value={option}
+                        as={Fragment}
+                      >
+                        {({ active, selected }) => (
+                          <li className={`py-1 flex justify-between cursor-pointer`}>
+                            {option.name}
+                            {selected && <CheckIcon className="text-stone-300 h-5 w-5"/>}
+                            {!selected && active && <DotIcon className="text-stone-300 h-5 w-5"/>}
+                          </li>
+                        )}
+                      </Combobox.Option>
+                    ))}
+                  </Combobox.Options>
+                </Transition>
+                </>
+              )}
           </>
         )}
       </Combobox>

--- a/src/components/ImagePicker/ImageThumbnail/ImageThumbnail.tsx
+++ b/src/components/ImagePicker/ImageThumbnail/ImageThumbnail.tsx
@@ -16,7 +16,7 @@ const ImageThumbnail: FunctionComponent<TImageThumbnailProps> = ({
   onDelete,
   onSave,
 }) => {
-  const [showIcons, setShowIcons] = useState(true)
+  const [showIcons, setShowIcons] = useState(false)
   const [showFields, setShowFields] = useState(false)
   const [data, setData] = useState(image)
   const { uniqueId, id, thumbnail, alt, saving } = image
@@ -41,10 +41,11 @@ const ImageThumbnail: FunctionComponent<TImageThumbnailProps> = ({
                         positioning={'absolute'}>
           <div className="relative w-full h-full max-h-28">
             <div
-              className={`rounded-md ${id && selected ? 'border-2 border-yellow-500' : ''}`}>
+              className={`rounded-md ${id && selected ? 'border-2 border-yellow-500' : ''}`}
+              onMouseEnter={() => setShowIcons(true)}
+              onMouseLeave={() => setShowIcons(false)}
+            >
               <img
-                onMouseEnter={() => setShowIcons(true)}
-                onMouseLeave={() => setShowIcons(false)}
                 className={`${id ? 'cursor-pointer' : 'opacity-50'} max-h-28 w-full object-contain`}
                 src={thumbnail}
                 alt={alt}

--- a/src/components/ImagePicker/ImageThumbnail/index.ts
+++ b/src/components/ImagePicker/ImageThumbnail/index.ts
@@ -1,4 +1,4 @@
-import ImageThumbnail from './component'
+import ImageThumbnail from './ImageThumbnail'
 
 export {
   ImageThumbnail

--- a/src/components/ImagePicker/index.ts
+++ b/src/components/ImagePicker/index.ts
@@ -1,4 +1,4 @@
-import ImagePicker from './component'
+import ImagePicker from './ImagePicker'
 
 export {
   ImagePicker

--- a/src/components/InfoBar/InfoBar.tsx
+++ b/src/components/InfoBar/InfoBar.tsx
@@ -2,10 +2,11 @@ import React, { FunctionComponent, JSX } from 'react'
 import clsx from 'clsx'
 import FieldMapper from '../../components/Forms/Fields/FieldMapper'
 import { FloatingBox } from '../FloatingBox'
-import { TTypesAllowed } from '../../types'
+import { TTypesAllowed } from '@/types'
 import ProfileImage from '../ProfileImage'
 import { Transition } from '@headlessui/react'
-import { TField } from '../../hooks/fieldTools'
+import { TField } from '@/hooks/fieldTools'
+import isEmpty from '@/utils/isEmpty'
 
 type TProps<T> = {
   onChange: (key: string, value: any) => void;
@@ -40,7 +41,10 @@ const InfoBar: FunctionComponent<TProps<any>> = ({
             <ProfileImage image={profileImage} openPicker={openProfileImagePicker}/>
           )}
           <ul className="font-serif text-serif-md leading-tight max-h-[50vh] overflow-y-scroll overflow-x-clip">
-            {fields.map((props, index) => {
+            {fields.filter((props) => {
+              const currentValue = data ? data[props.name as keyof TTypesAllowed] : null
+              return !(disabled && isEmpty(currentValue))
+            }).map((props, index) => {
               const currentValue = data ? data[props.name as keyof TTypesAllowed] : null
               return <FieldMapper
                 key={index}

--- a/src/components/SmallSansSerifText/SansSerifText.tsx
+++ b/src/components/SmallSansSerifText/SansSerifText.tsx
@@ -6,6 +6,7 @@ const sansSerifTextVariants = cva(
   {
     variants: {
       size: {
+        'xxs': 'text-xxs',
         'xs': 'text-xs',
         'normal': '',
       },

--- a/src/hooks/DataManagers/Images/useImageIndexDataManager.ts
+++ b/src/hooks/DataManagers/Images/useImageIndexDataManager.ts
@@ -1,0 +1,22 @@
+import { TImage } from '@/types'
+import { useIndexDataManager, TIndexDataManager } from '../useIndexDataManager'
+import ImageService from '@/services/ApiService/Images/ImageService'
+import { imagesIndexSlice } from '@/reducers/image/imagesIndexSlice'
+
+type TImageIndexDataManager = TIndexDataManager<TImage> & {
+  images?: TImage[]
+}
+
+const useNoteIndexDataManager = (): TImageIndexDataManager => {
+  const manager = useIndexDataManager(
+    'images',
+    imagesIndexSlice,
+    ImageService,
+  )
+  return {
+    ...manager,
+    images: manager.list,
+  }
+}
+
+export default useNoteIndexDataManager

--- a/src/hooks/DataManagers/useAuthUserDataManager.ts
+++ b/src/hooks/DataManagers/useAuthUserDataManager.ts
@@ -1,8 +1,8 @@
-import { authUserSlice } from '../../reducers/auth/authUserSlice'
-import { useAppDispatch, useAppSelector } from '../../hooks'
+import { authUserSlice } from '@/reducers/auth/authUserSlice'
+import { useAppDispatch, useAppSelector } from '@/hooks'
 import { useCallback } from 'react'
-import { TUser } from '../../types'
-import { TQueryParams } from '../../services/ApiService/types'
+import { TPermission, TUser } from '@/types'
+import { TQueryParams } from '@/services/ApiService/types'
 import userService, { TUserRequest } from '../../services/ApiService/User/UserService'
 import {
   hasCharactersAttachableDataManager, hasFavouritesAttachableDataManager, hasPinsAttachableDataManager,
@@ -18,6 +18,9 @@ type TAuthUserDataManager = {
   viewOwn: (query?: TQueryParams) => Promise<TUser>,
   view: (id: string | number, query?: TQueryParams) => Promise<TUser>,
   update: (id: string | number, payload: Partial<TUserRequest>, query?: TQueryParams) => Promise<TUser>,
+
+  // utility
+  hasPermission: (permission: TPermission) => boolean
 } & hasCharactersAttachableDataManager & hasFavouritesAttachableDataManager & hasPinsAttachableDataManager
 
 /**
@@ -63,6 +66,17 @@ const useAuthUserDataManager = (): TAuthUserDataManager => {
     return data.data
   }, [])
 
+  const hasPermission = (permission: TPermission): boolean => {
+    if (!entity?.permissions) {
+      return false;
+    }
+    return entity.permissions.some(value => {
+      return value.permission === permission.permission
+        && value.permissionableType === permission.permissionableType
+        && value.permissionableId === permission.permissionableId
+    })
+  }
+
   return {
     user: entity,
     setData,
@@ -74,6 +88,7 @@ const useAuthUserDataManager = (): TAuthUserDataManager => {
     characters: useCharacterableDataManager(authUserSlice, userService.characters),
     favourites: useFavouritableDataManager(authUserSlice, userService.favourites),
     pins: useAttachableDataManager('pins', authUserSlice, userService.pins),
+    hasPermission
   }
 }
 

--- a/src/hooks/DataManagers/useIndexDataManager.ts
+++ b/src/hooks/DataManagers/useIndexDataManager.ts
@@ -3,16 +3,18 @@ import { useCallback } from 'react'
 import { TIndexApi, TQueryParams } from '@/services/ApiService/types'
 import { Slice } from '@reduxjs/toolkit'
 import { TIndexSliceState } from '@/reducers/createIndexSlice'
-import { TOptionList } from '@/types'
 
 export type TIndexDataManager<TEntity> = {
   list?: (TEntity)[],
   setData: (data: TEntity[]) => any,
+  setOne: (data: TEntity) => any,
+  updateOne: (data: TEntity) => any,
+  removeOne: (id: string|number) => any,
   index: (query?: TQueryParams) => Promise<TEntity[]>,
 }
 
-export const useIndexDataManager = <TEntity extends TOptionList, TIndexResponse extends TEntity[]> (
-  name: 'campaigns' | 'compendia' | 'notebooks' | 'notes' | 'systems' | 'imageTypes' | 'governmentTypes' | 'locationTypes' | 'questTypes' | 'encounterTypes',
+export const useIndexDataManager = <TEntity, TIndexResponse extends TEntity[]> (
+  name: 'campaigns' | 'compendia' | 'notebooks' | 'notes' | 'systems' | 'images' | 'imageTypes' | 'governmentTypes' | 'locationTypes' | 'questTypes' | 'encounterTypes',
   slice: Slice<TIndexSliceState<TEntity>>,
   api: TIndexApi<TIndexResponse>,
 ): TIndexDataManager<TEntity> => {
@@ -26,6 +28,18 @@ export const useIndexDataManager = <TEntity extends TOptionList, TIndexResponse 
     dispatch(slice.actions.set(data))
   }, [])
 
+  const setOne = useCallback((one: TEntity) => {
+    dispatch(slice.actions.setOne(one))
+  }, [])
+
+  const updateOne = useCallback((one: TEntity) => {
+    dispatch(slice.actions.updateOne(one))
+  }, [])
+
+  const removeOne = useCallback((id: string|number) => {
+    dispatch(slice.actions.removeOne(id))
+  }, [])
+
   const index = useCallback(async (query: TQueryParams = {}) => {
     const { data } = await api.index(query)
     setData(data.data)
@@ -35,6 +49,9 @@ export const useIndexDataManager = <TEntity extends TOptionList, TIndexResponse 
   return {
     list,
     setData,
+    setOne,
+    updateOne,
+    removeOne,
     index
   }
 }

--- a/src/hooks/Forms/usePostForm.ts
+++ b/src/hooks/Forms/usePostForm.ts
@@ -59,7 +59,7 @@ const usePostForm = <T extends TGenericPost, R> ({
   const { entity, store, update, destroy, view } = manager
 
   const isNew = useMemo(() => id === 'new', [id])
-  const canEdit = useMemo(() => isNew || entity?.canUpdate !== undefined, [isNew, entity?.canUpdate])
+  const canEdit = useMemo(() => isNew || entity?.canUpdate === true, [isNew, entity?.canUpdate])
 
   const imageHandler = useImageSelection<T>({ manager, canHaveProfileImage })
   const pinHandler = usePinHandler<T>({ manager })
@@ -92,6 +92,7 @@ const usePostForm = <T extends TGenericPost, R> ({
     id,
     isNew,
     mapData,
+    canEdit,
 
     onFetch: () => view(id, { include: `${include ? `${include};` : ''}images` }),
     onCreate: (data: T) => store(mapData(data), { include }),

--- a/src/hooks/useFormHandling/useFormHandling.ts
+++ b/src/hooks/useFormHandling/useFormHandling.ts
@@ -12,6 +12,7 @@ type TProps<T, R> = {
   id: string | number | 'new'
   isNew: boolean,
   mapData: (data: T) => R;
+  canEdit: boolean;
 
   // API
   onFetch: () => Promise<T>,
@@ -33,6 +34,7 @@ const useFormHandling = <T, R> ({
   id,
   isNew,
   mapData,
+  canEdit,
 
   fetchOnMount = true,
   onFetch,
@@ -111,6 +113,9 @@ const useFormHandling = <T, R> ({
 
   // Save data function
   const handleOnSave = async () => {
+    if (!canEdit) {
+      return;
+    }
     if (!data) {
       console.error('cannot save empty data')
       return

--- a/src/hooks/useLink.ts
+++ b/src/hooks/useLink.ts
@@ -45,7 +45,7 @@ const useLink = (entityPath: string, id: string | number): string => {
   const { compendiumPath } = useUrlFormatter()
   const { campaign } = useCampaignDataManager()
 
-  return makeLink(entityPath, id, compendiumPath, campaign!.slug)
+  return makeLink(entityPath, id, compendiumPath, campaign?.slug)
 }
 
 export default useLink;

--- a/src/hooks/usePinHandler.ts
+++ b/src/hooks/usePinHandler.ts
@@ -77,12 +77,18 @@ const usePinHandler = <T extends TGenericPostBasic> ({ manager }: TProps<T>): TP
   }, [campaign, manager.entity?.id, manager.entityName])
 
   const permittedUsers = useMemo(() => {
+    if (!campaign?.users) {
+      return []
+    }
+    if (campaign.permissions.some(permission => permission.permissionableId === manager.entity?.id)) {
+      return campaign.users;
+    }
     return campaign?.users.filter((user) => {
       return user.permissions?.some(permission => {
         return permission.permissionableId === manager.entity?.id
       })
     }) ?? []
-  }, [campaign])
+  }, [campaign?.users])
 
   const options: TPinForOption[] = useMemo(() => {
     if (!campaign) {

--- a/src/hooks/usePlayerCharacterHandler.ts
+++ b/src/hooks/usePlayerCharacterHandler.ts
@@ -1,8 +1,8 @@
 import { useCampaignDataManager } from './DataManagers'
-import { TPlayerCharacterHandler } from '../components/Post/types'
+import { TPlayerCharacterHandler } from '@/components/Post/types'
 import useAuthUserDataManager from './DataManagers/useAuthUserDataManager'
 import { useCallback, useMemo } from 'react'
-import { TSelectOption } from '../components/Forms/Fields/FieldMapper'
+import { TSelectOption } from '@/components/Forms/Fields/FieldMapper'
 import useUserDataManager from './DataManagers/Campaigns/useUserDataManager'
 import { TCharacterDataManager } from './DataManagers/Compendia/useCharacterDataManager'
 
@@ -54,7 +54,13 @@ const usePlayerCharacterHandler = ({ manager }: TProps): TPlayerCharacterHandler
   }, [campaign?.users, manager.character])
 
   const permittedUsers = useMemo(() => {
-    return campaign?.users.filter((user) => {
+    if (!campaign?.users) {
+      return []
+    }
+    if (campaign.permissions.some(permission => permission.permissionableId === manager.entity?.id)) {
+      return campaign.users;
+    }
+    return campaign.users.filter((user) => {
       return user.permissions?.some(permission => {
         return permission.permissionableId === manager.entity?.id
       })

--- a/src/pages/Notebook/Notebook.tsx
+++ b/src/pages/Notebook/Notebook.tsx
@@ -11,8 +11,8 @@ const Notebook: FunctionComponent = (): JSX.Element => {
 
   const form = useNotebookForm({
     notebookId,
-    onCreated: (data) => navigate(`/notebooks/${data.slug}`),
-    onDeleted: () => navigate(`/notebooks`)
+    onCreated: (data) => navigate(`/notes/notebooks/${data.slug}`),
+    onDeleted: () => navigate(`/notes/notebooks`)
   });
 
   return (

--- a/src/pages/Notebook/NotesWrapper.tsx
+++ b/src/pages/Notebook/NotesWrapper.tsx
@@ -1,7 +1,7 @@
 import React, { JSX, useEffect, useMemo } from 'react'
 import { Outlet, useNavigate, useParams } from 'react-router-dom'
 import Sidebar from '../../components/Sidebar/Sidebar'
-import { LucideProps, StickyNoteIcon } from 'lucide-react'
+import { BookIcon, LucideProps, PenBoxIcon, StickyNoteIcon } from 'lucide-react'
 import useNoteDataManager
   from '../../hooks/DataManagers/Notebooks/useNoteDataManager'
 import {
@@ -46,7 +46,7 @@ const NotesWrapper = (): JSX.Element => {
             title: notebook.name,
             to: `${prefix}/notes/notebooks/${(notebook.slug)}`,
             icon: (props: LucideProps) =>
-              <StickyNoteIcon {...props}/>,
+              <BookIcon {...props}/>,
             onDelete: () => destroyNotebook(notebook.slug),
             addNewLink: `${prefix}/notes/new`,
             addNewLinkState: { notebook },
@@ -63,7 +63,7 @@ const NotesWrapper = (): JSX.Element => {
               map((note) => ({
                 title: note.name,
                 to: `${prefix}/notes/${note.slug}`,
-                icon: (props: LucideProps) => <StickyNoteIcon {...props}/>,
+                icon: (props: LucideProps) => <PenBoxIcon {...props}/>,
                 onDelete: () => destroyNote(note.slug)
                   .then(() => onDeleted()),
               })),

--- a/src/reducers/image/imagesIndexSlice.ts
+++ b/src/reducers/image/imagesIndexSlice.ts
@@ -1,0 +1,6 @@
+import { TImage } from '@/types'
+import createIndexSlice from '../createIndexSlice'
+
+export const imagesIndexSlice = createIndexSlice<TImage>('imagessIndex')
+
+export default imagesIndexSlice.reducer

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -18,6 +18,8 @@ import useAuthUserDataManager
 import LoadingWrapper from '../components/LoadingWrapper'
 import { useNoteIndexDataManager } from '@/hooks/DataManagers'
 import usePostDataManager from '@/hooks/DataManagers/usePostDataManager'
+import useImageIndexDataManager
+  from '@/hooks/DataManagers/Images/useImageIndexDataManager'
 
 export const ProtectedRoute = (): JSX.Element => {
 
@@ -35,26 +37,32 @@ export const ProtectedRoute = (): JSX.Element => {
   const locationTypeIndexDataManager = useLocationTypeIndexDataManager()
   const questTypeIndexDataManager = useQuestTypeIndexDataManager()
   const encounterTypeIndexDataManager = useEncounterTypeIndexDataManager()
+  const imageIndexDataManager = useImageIndexDataManager()
 
   // Here we will be adding the missing items where needed
   useEffect(() => {
     if (token) {
-      const promises = [
-        systemIndexDataManager.index(),
-        compendiumIndexDataManager.index(),
-        campaignIndexDataManager.index(),
-        notebookIndexDataManager.index(),
-        noteIndexDataManager.index({ include: 'notebook:id,slug,name' }),
-        imageTypeIndexDataManager.index(),
-        governmentTypeIndexDataManager.index(),
-        locationTypeIndexDataManager.index(),
-        questTypeIndexDataManager.index(),
-        encounterTypeIndexDataManager.index(),
-        authUserDataManager.viewOwn({ include: 'favourites;favourites.favouritable;pins;pins.pinnable;characters' }),
-      ]
-      Promise.all(promises).then(() => {
-        setLoading({ init: false })
-      })
+      authUserDataManager.viewOwn({ include: 'favourites;favourites.favouritable;pins;pins.pinnable;characters;permissions' }).
+        then((user) => {
+          const promises = [
+            compendiumIndexDataManager.index(),
+            campaignIndexDataManager.index(),
+            notebookIndexDataManager.index(),
+            noteIndexDataManager.index({ include: 'notebook:id,slug,name' }),
+            imageTypeIndexDataManager.index(),
+            governmentTypeIndexDataManager.index(),
+            locationTypeIndexDataManager.index(),
+            questTypeIndexDataManager.index(),
+            encounterTypeIndexDataManager.index(),
+            imageIndexDataManager.index(),
+          ]
+          if (user.canViewSystems) {
+            promises.push(systemIndexDataManager.index())
+          }
+          Promise.all(promises).then(() => {
+            setLoading({ init: false })
+          })
+        })
     }
   }, [token])
 

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -256,6 +256,10 @@ const Routes = (): JSX.Element => {
           path: '/profile',
           element: <>TODO: User Profile</>,
         },
+        {
+          path: '*',
+          element: <NotFound/>,
+        },
       ],
     },
   ]
@@ -274,6 +278,10 @@ const Routes = (): JSX.Element => {
       path: '/register',
       element: <Register/>,
     },
+    {
+      path: '*',
+      element: <NotFound/>,
+    },
   ]
 
   // Combine and conditionally include routes based on authentication status
@@ -284,11 +292,7 @@ const Routes = (): JSX.Element => {
       children: [
         ...routesForPublic,
         ...(!token ? routesForNotAuthenticatedOnly : []), // only add these conditionally
-        ...routesForAuthenticatedOnly,
-        {
-          path: '*',
-          element: <NotFound/>,
-        },
+        ...routesForAuthenticatedOnly
       ],
     },
   ])

--- a/src/store.ts
+++ b/src/store.ts
@@ -37,12 +37,14 @@ import questTypesIndexSlice from './reducers/questType/questTypesIndexSlice'
 import encounterTypesIndexSlice from './reducers/encounterType/encounterTypesIndexSlice'
 import authUserSlice from './reducers/auth/authUserSlice'
 import userSlice from './reducers/auth/userSlice'
+import imagesIndexSlice from '@/reducers/image/imagesIndexSlice'
 
 export const store = configureStore({
   reducer: {
     auth: authSlice,
     authUser: authUserSlice,
     user: userSlice,
+    images: imagesIndexSlice,
     // system
     post: postSlice,
     // indexes

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,9 @@ export type TUser = {
   favourites?: TFavourite[];
   characters?: TCharacter[];
   permissions?: TPermission[];
+  canViewSystems: boolean;
+  canCreateCompendia: boolean;
+  canCreateCampaigns: boolean;
 }
 
 export type TInvitation = {

--- a/src/utils/isEmpty.ts
+++ b/src/utils/isEmpty.ts
@@ -1,0 +1,9 @@
+const isEmpty = (value: any): boolean => {
+  return (
+    value == null || // From standard.js: Always use === - but obj == null is allowed to check null || undefined
+    (typeof value === 'object' && Object.keys(value).length === 0) ||
+    (typeof value === 'string' && value.trim().length === 0)
+  )
+}
+
+export default isEmpty

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,7 @@ module.exports = {
         'width': 'width'
       },
       fontSize: {
+        'xxs': '0.65rem',
         'serif-md': '1.25rem',
         'serif-lg': '1.35rem'
       }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import path from "path"
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import mkcert from 'vite-plugin-mkcert'
 
 export default defineConfig({
     plugins: [
@@ -10,7 +11,8 @@ export default defineConfig({
                     ['@babel/plugin-proposal-decorators', { version: '2023-05' }], // https://github.com/owlsdepartment/vite-plugin-babel/issues/24
                 ],
             },
-        })
+        }),
+        mkcert()
     ],
     resolve: {
         alias: {


### PR DESCRIPTION
Changed favourites to be ordered by type
Hiding fields if you cant update them and they're empty Fixed issue where you couldnt click on the save images button Stop it loading images every time you open the picket, and load them on start Fixed canEdit to look for canUpdate === true, instead of !== undefined Fixed pinHandler and playerCharacterHandler not showing permitted users when the campaign had the permission Fixed notebook redirect
Fixed redirect to NotFound did not allow you to get back to authed paged